### PR TITLE
Correct Dust Cloud Generation

### DIFF
--- a/RNGReporter/Objects/Frame.cs
+++ b/RNGReporter/Objects/Frame.cs
@@ -79,7 +79,7 @@ namespace RNGReporter.Objects
 
         public string CaveSpotting
         {
-            get { return RngResultNext >> 28 == 0 ? "Trigger at 20th step" : ""; }
+            get { return ((((ulong)(RngResultNext) * 1000) >> 32) < 100) ? "Trigger at 20th step" : ""; }
         }
 
         // Chatot response for 4th Gen Games


### PR DESCRIPTION
This corrects the dust cloud generation from rand(16) == 0 to what the game actually uses which is rand(1000) < 100. The previous implementation ends up being correct around 96% of the time, but isn't fully accurate to the game.

I believe this is the only relevant place this should be changed, but I'm not familiar with the rngre code base.