### PR TITLE
Fix Gen 5 TimeFinder day interval calculation

### DIFF
--- a/RNGReporter/TimeFinder5th.cs
+++ b/RNGReporter/TimeFinder5th.cs
@@ -971,10 +971,7 @@ namespace RNGReporter
 
             foreach (int month in months)
             {
-                float interval = ((float)DateTime.DaysInMonth((int)year, month) / cpus + (float)0.05);
-
-                var dayMin = (int)(interval * listIndex + 1);
-                var dayMax = (int)(interval * (listIndex + 1));
+                GetDayIntervalForCpu((int)year, month, listIndex, out var dayMin, out var dayMax);
 
                 string yearMonth = String.Format("{0:00}", year % 2000) + String.Format("{0:00}", month);
                 for (int buttonCount = 0; buttonCount < keypressList.Count; buttonCount++)
@@ -2095,10 +2092,7 @@ namespace RNGReporter
 
             foreach (int month in months)
             {
-                float interval = ((float)DateTime.DaysInMonth((int)year, month) / cpus + (float)0.05);
-
-                var dayMin = (int)(interval * listIndex + 1);
-                var dayMax = (int)(interval * (listIndex + 1));
+                GetDayIntervalForCpu((int)year, month, listIndex, out var dayMin, out var dayMax);
 
                 string yearMonth = String.Format("{0:00}", year % 2000) + String.Format("{0:00}", month);
                 for (int buttonCount = 0; buttonCount < keypressList.Count; buttonCount++)
@@ -3900,10 +3894,7 @@ namespace RNGReporter
 
             foreach (int month in months)
             {
-                float interval = ((float)DateTime.DaysInMonth((int)year, month) / cpus + (float)0.05);
-
-                var dayMin = (int)(interval * listIndex + 1);
-                var dayMax = (int)(interval * (listIndex + 1));
+                GetDayIntervalForCpu((int)year, month, listIndex, out var dayMin, out var dayMax);
 
                 string yearMonth = String.Format("{0:00}", year % 2000) + String.Format("{0:00}", month);
                 for (int buttonCount = 0; buttonCount < keypressList.Count; buttonCount++)
@@ -4005,6 +3996,24 @@ namespace RNGReporter
                     }
                 }
             }
+        }
+
+        private void GetDayIntervalForCpu(int year, int month, int cpuIndex, out int dayMin, out int dayMax)
+        {
+            int totalDays = DateTime.DaysInMonth(year, month);
+            // Divide the days evenly between CPUs
+            int daysPerCpu = totalDays / cpus;
+            // Extra days to distribute among first CPUs, if any.
+            // This also is the last index in the cpu array that would get an extra day
+            int extraDays = totalDays % cpus;
+
+            // Calculate min/max days of the month this cpu will process
+            dayMin = cpuIndex < extraDays
+                ? (cpuIndex * (daysPerCpu + 1)) + 1
+                : (extraDays * (daysPerCpu + 1)) + 1 + ((cpuIndex - extraDays) * daysPerCpu);
+            dayMax = cpuIndex < extraDays
+                ? dayMin + daysPerCpu
+                : dayMin + daysPerCpu - 1;
         }
 
         private void dataGridViewPickup_ColumnHeaderMouseClick(object sender, DataGridViewCellMouseEventArgs e)


### PR DESCRIPTION
The current logic used by the Gen5 time finder to calculate the day interval that each CPU thread will calculate results for is prone to errors if the number of CPUs is not an exact multiple (or close enough) of the number of days of the month. In some situations, invalid dates are generated (e.g. January 32) causing the application to crash. Also, overlapping day ranges can be created, which could cause duplication of the same work across threads

![image](https://github.com/user-attachments/assets/f015c138-fc77-45bb-89ea-f085eddbd640)

With the proposed changes, each CPU gets the same number of days. If there are any remaining days, each CPU gets an extra day until all days are assigned. No overlapping date ranges are created.

For example, in a machine with 6 CPUS, searching in the month of February 2025:
Each CPU gets 28/6 days = 4 for a total of 24 days assigned. Then, 28%6 = 4 remaining days still need to be allocated, so CPUs 0-3 get an extra day on top of the initial 4.

|CPU|TotalDays|MinDay|MaxDay|
|:---:|:---:|:---:|:---:|
|0|5|1|5|
|1|5|6|10|
|2|5|11|15|
|3|5|16|20|
|4|4|21|24|
|5|4|25|28|

resolves #5 